### PR TITLE
Updating documentation to match our team's fork

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -133,8 +133,8 @@ asciidoctor {
         idprefix: '',  // for compatibility with GitHub preview
         idseparator: '-',
         'site-root': "${sourceDir}",  // must be the same as sourceDir, do not modify
-        'site-name': 'AddressBook-Level3',
-        'site-githuburl': 'https://github.com/se-edu/addressbook-level3',
+        'site-name': 'Expense Tracker',
+        'site-githuburl': 'https://github.com/AY1920S1-CS2103T-T11-1/main',
         'site-seedu': true,  // delete this line if your project is not a fork (not a SE-EDU project)
     ]
 

--- a/docs/DeveloperGuide.adoc
+++ b/docs/DeveloperGuide.adoc
@@ -12,7 +12,7 @@ ifdef::env-github[]
 :note-caption: :information_source:
 :warning-caption: :warning:
 endif::[]
-:repoURL: https://github.com/se-edu/addressbook-level3/tree/master
+:repoURL: https://github.com/AY1920S1-CS2103T-T11-1/main
 
 By: `Team SE-EDU`      Since: `Jun 2016`      Licence: `MIT`
 

--- a/docs/UserGuide.adoc
+++ b/docs/UserGuide.adoc
@@ -12,7 +12,7 @@ ifdef::env-github[]
 :tip-caption: :bulb:
 :note-caption: :information_source:
 endif::[]
-:repoURL: https://github.com/se-edu/addressbook-level3
+:repoURL: https://github.com/AY1920S1-CS2103T-T11-1/main
 
 By: `Team SE-EDU`      Since: `Jun 2016`      Licence: `MIT`
 


### PR DESCRIPTION
Configure the site-wide documentation settings in build.gradle, such as the site-name, to suit the team's project - "Expense Tracker".
Replace the URL in the attribute repoURL in DeveloperGuide.adoc and UserGuide.adoc with the URL of team's fork.