### PR TITLE
Separate command validation from execution

### DIFF
--- a/src/main/java/seedu/address/logic/LogicManager.java
+++ b/src/main/java/seedu/address/logic/LogicManager.java
@@ -45,7 +45,7 @@ public class LogicManager implements Logic {
 
         CommandResult commandResult;
         Command command = addressBookParser.parseCommand(commandText, model.getUserPrefs());
-        commandResult = command.execute(model);
+        commandResult = command.run(model);
 
         try {
             storage.saveAddressBook(model.getAddressBook());

--- a/src/main/java/seedu/address/logic/commands/AddCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddCommand.java
@@ -41,12 +41,17 @@ public class AddCommand extends Command {
     }
 
     @Override
-    public CommandResult execute(Model model) throws CommandException {
+    protected void validate(Model model) throws CommandException {
         requireNonNull(model);
 
         if (model.hasExpense(toAdd)) {
             throw new CommandException(MESSAGE_DUPLICATE_EXPENSE);
         }
+    }
+
+    @Override
+    protected CommandResult execute(Model model) {
+        requireNonNull(model);
 
         model.addExpense(toAdd);
         return new CommandResult(String.format(MESSAGE_SUCCESS, toAdd));

--- a/src/main/java/seedu/address/logic/commands/AliasCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AliasCommand.java
@@ -37,7 +37,7 @@ public class AliasCommand extends Command {
     }
 
     @Override
-    public CommandResult execute(Model model) throws CommandException {
+    protected void validate(Model model) throws CommandException {
         requireNonNull(model);
 
         // if command_word is reserved
@@ -53,9 +53,13 @@ public class AliasCommand extends Command {
                 || model.getUserPrefs().aliasCommandWordIsAlias(commandWord)) {
             throw new CommandException(MESSAGE_RECURSIVE_WARNING);
         }
+    }
+
+    @Override
+    protected CommandResult execute(Model model) {
+        requireNonNull(model);
 
         model.addUserAlias(toAdd);
-
         return new CommandResult(String.format(MESSAGE_SUCCESS, toAdd.getAliasName()));
     }
 

--- a/src/main/java/seedu/address/logic/commands/BudgetCommand.java
+++ b/src/main/java/seedu/address/logic/commands/BudgetCommand.java
@@ -39,12 +39,18 @@ public class BudgetCommand extends Command {
     }
 
     @Override
-    public CommandResult execute(Model model) throws CommandException {
+    protected void validate(Model model) throws CommandException {
         requireNonNull(model);
 
         if (model.hasBudget(toAdd)) {
             throw new CommandException(MESSAGE_DUPLICATE_BUDGET);
         }
+    }
+
+    @Override
+    protected CommandResult execute(Model model) {
+        requireNonNull(model);
+
         model.addBudget(toAdd);
         model.setPrimary(toAdd);
         return new CommandResult(String.format(MESSAGE_SUCCESS, toAdd));

--- a/src/main/java/seedu/address/logic/commands/ClearCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ClearCommand.java
@@ -13,9 +13,13 @@ public class ClearCommand extends Command {
     public static final String COMMAND_WORD = "clear";
     public static final String MESSAGE_SUCCESS = "Address book has been cleared!";
 
+    @Override
+    protected void validate(Model model) {
+        // No validation necessary.
+    }
 
     @Override
-    public CommandResult execute(Model model) {
+    protected CommandResult execute(Model model) {
         requireNonNull(model);
         model.setAddressBook(new AddressBook());
         return new CommandResult(MESSAGE_SUCCESS);

--- a/src/main/java/seedu/address/logic/commands/Command.java
+++ b/src/main/java/seedu/address/logic/commands/Command.java
@@ -9,12 +9,29 @@ import seedu.address.model.Model;
 public abstract class Command {
 
     /**
-     * Executes the command and returns the result message.
+     * Validates the command parameters.
+     * @throws CommandException If parameters are invalid.
+     */
+    protected abstract void validate(Model model) throws CommandException;
+
+    /**
+     * Executes the command, without validation, and returns the result message.
      *
      * @param model {@code Model} which the command should operate on.
      * @return feedback message of the operation result for display
      * @throws CommandException If an error occurs during command execution.
      */
-    public abstract CommandResult execute(Model model) throws CommandException;
+    protected abstract CommandResult execute(Model model) throws CommandException;
 
+    /**
+     * Executes the command with validation and returns the result message.
+     *
+     * @param model {@code Model} which the command should operate on.
+     * @return feedback message of the operation result for display
+     * @throws CommandException If an error occurs during command execution.
+     */
+    public CommandResult run(Model model) throws CommandException {
+        validate(model);
+        return execute(model);
+    }
 }

--- a/src/main/java/seedu/address/logic/commands/DeleteCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteCommand.java
@@ -31,13 +31,19 @@ public class DeleteCommand extends Command {
     }
 
     @Override
-    public CommandResult execute(Model model) throws CommandException {
+    protected void validate(Model model) throws CommandException {
         requireNonNull(model);
         List<Expense> lastShownList = model.getFilteredExpenseList();
 
         if (targetIndex.getZeroBased() >= lastShownList.size()) {
             throw new CommandException(Messages.MESSAGE_INVALID_EXPENSE_DISPLAYED_INDEX);
         }
+    }
+
+    @Override
+    protected CommandResult execute(Model model) {
+        requireNonNull(model);
+        List<Expense> lastShownList = model.getFilteredExpenseList();
 
         Expense expenseToDelete = lastShownList.get(targetIndex.getZeroBased());
         model.deleteExpense(expenseToDelete);

--- a/src/main/java/seedu/address/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditCommand.java
@@ -59,20 +59,28 @@ public class EditCommand extends Command {
     }
 
     @Override
-    public CommandResult execute(Model model) throws CommandException {
+    protected void validate(Model model) throws CommandException {
         requireNonNull(model);
-        List<Expense> lastShownList = model.getFilteredExpenseList();
 
+        List<Expense> lastShownList = model.getFilteredExpenseList();
         if (index.getZeroBased() >= lastShownList.size()) {
             throw new CommandException(Messages.MESSAGE_INVALID_EXPENSE_DISPLAYED_INDEX);
         }
 
         Expense expenseToEdit = lastShownList.get(index.getZeroBased());
         Expense editedExpense = createEditedExpense(expenseToEdit, editExpenseDescriptor);
-
         if (!expenseToEdit.isSameExpense(editedExpense) && model.hasExpense(editedExpense)) {
             throw new CommandException(MESSAGE_DUPLICATE_EXPENSE);
         }
+    }
+
+    @Override
+    protected CommandResult execute(Model model) {
+        requireNonNull(model);
+
+        List<Expense> lastShownList = model.getFilteredExpenseList();
+        Expense expenseToEdit = lastShownList.get(index.getZeroBased());
+        Expense editedExpense = createEditedExpense(expenseToEdit, editExpenseDescriptor);
 
         model.setExpense(expenseToEdit, editedExpense);
         model.updateFilteredExpenseList(PREDICATE_SHOW_ALL_EXPENSES);

--- a/src/main/java/seedu/address/logic/commands/EventCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EventCommand.java
@@ -41,12 +41,17 @@ public class EventCommand extends Command {
     }
 
     @Override
-    public CommandResult execute(Model model) throws CommandException {
+    protected void validate(Model model) throws CommandException {
         requireNonNull(model);
 
         if (model.hasEvent(toAdd)) {
             throw new CommandException(MESSAGE_DUPLICATE_EVENT);
         }
+    }
+
+    @Override
+    protected CommandResult execute(Model model) {
+        requireNonNull(model);
 
         model.addEvent(toAdd);
         return new CommandResult(String.format(MESSAGE_SUCCESS, toAdd));

--- a/src/main/java/seedu/address/logic/commands/ExitCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ExitCommand.java
@@ -12,7 +12,12 @@ public class ExitCommand extends Command {
     public static final String MESSAGE_EXIT_ACKNOWLEDGEMENT = "Exiting Address Book as requested ...";
 
     @Override
-    public CommandResult execute(Model model) {
+    protected void validate(Model model) {
+        // No validation necessary.
+    }
+
+    @Override
+    protected CommandResult execute(Model model) {
         return new CommandResult(MESSAGE_EXIT_ACKNOWLEDGEMENT, false, true);
     }
 

--- a/src/main/java/seedu/address/logic/commands/FindCommand.java
+++ b/src/main/java/seedu/address/logic/commands/FindCommand.java
@@ -26,7 +26,12 @@ public class FindCommand extends Command {
     }
 
     @Override
-    public CommandResult execute(Model model) {
+    protected void validate(Model model) {
+        // No validation necessary.
+    }
+
+    @Override
+    protected CommandResult execute(Model model) {
         requireNonNull(model);
         model.updateFilteredExpenseList(predicate);
         return new CommandResult(

--- a/src/main/java/seedu/address/logic/commands/HelpCommand.java
+++ b/src/main/java/seedu/address/logic/commands/HelpCommand.java
@@ -15,7 +15,12 @@ public class HelpCommand extends Command {
     public static final String SHOWING_HELP_MESSAGE = "Opened help window.";
 
     @Override
-    public CommandResult execute(Model model) {
+    protected void validate(Model model) {
+        // No validation necessary.
+    }
+
+    @Override
+    protected CommandResult execute(Model model) {
         return new CommandResult(SHOWING_HELP_MESSAGE, true, false);
     }
 }

--- a/src/main/java/seedu/address/logic/commands/ListCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ListCommand.java
@@ -14,9 +14,13 @@ public class ListCommand extends Command {
 
     public static final String MESSAGE_SUCCESS = "Listed all expenses";
 
+    @Override
+    protected void validate(Model model) {
+        // No validation necessary.
+    }
 
     @Override
-    public CommandResult execute(Model model) {
+    protected CommandResult execute(Model model) {
         requireNonNull(model);
         model.updateFilteredExpenseList(PREDICATE_SHOW_ALL_EXPENSES);
         return new CommandResult(MESSAGE_SUCCESS);

--- a/src/main/java/seedu/address/logic/commands/RemindersCommand.java
+++ b/src/main/java/seedu/address/logic/commands/RemindersCommand.java
@@ -15,7 +15,12 @@ public class RemindersCommand extends Command {
     public static final String MESSAGE_SUCCESS = "Listed all reminders";
 
     @Override
-    public CommandResult execute(Model model) {
+    protected void validate(Model model) {
+        // No validation necessary.
+    }
+
+    @Override
+    protected CommandResult execute(Model model) {
         requireNonNull(model);
         model.updateFilteredExpenseList(PREDICATE_SHOW_ALL_EXPENSES);
         return new CommandResult(MESSAGE_SUCCESS);

--- a/src/test/java/seedu/address/logic/commands/AddCommandIntegrationTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddCommandIntegrationTest.java
@@ -26,7 +26,7 @@ public class AddCommandIntegrationTest {
     // No addCommand should not be the same as another addCommand, odds are unlikely because of use of UUID
 
     @Test
-    public void execute_duplicateExpense_throwsCommandException() {
+    public void run_duplicateExpense_throwsCommandException() {
         Expense expenseInList = model.getAddressBook().getExpenseList().get(0);
         assertCommandFailure(new AddCommand(expenseInList), model, AddCommand.MESSAGE_DUPLICATE_EXPENSE);
     }

--- a/src/test/java/seedu/address/logic/commands/AddCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddCommandTest.java
@@ -35,23 +35,23 @@ public class AddCommandTest {
     }
 
     @Test
-    public void execute_expenseAcceptedByModel_addSuccessful() throws Exception {
+    public void run_expenseAcceptedByModel_addSuccessful() throws Exception {
         ModelStubAcceptingExpenseAdded modelStub = new ModelStubAcceptingExpenseAdded();
         Expense validExpense = new ExpenseBuilder().build();
 
-        CommandResult commandResult = new AddCommand(validExpense).execute(modelStub);
+        CommandResult commandResult = new AddCommand(validExpense).run(modelStub);
 
         assertEquals(String.format(AddCommand.MESSAGE_SUCCESS, validExpense), commandResult.getFeedbackToUser());
         assertEquals(Arrays.asList(validExpense), modelStub.expensesAdded);
     }
 
     @Test
-    public void execute_duplicateExpense_throwsCommandException() {
+    public void run_duplicateExpense_throwsCommandException() {
         Expense validExpense = new ExpenseBuilder().build();
         AddCommand addCommand = new AddCommand(validExpense);
         ModelStub modelStub = new ModelStubWithExpense(validExpense);
 
-        assertThrows(CommandException.class, AddCommand.MESSAGE_DUPLICATE_EXPENSE, () -> addCommand.execute(modelStub));
+        assertThrows(CommandException.class, AddCommand.MESSAGE_DUPLICATE_EXPENSE, () -> addCommand.run(modelStub));
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/commands/AliasCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AliasCommandTest.java
@@ -49,19 +49,19 @@ public class AliasCommandTest {
     }
 
     @Test
-    public void execute_aliasNameIsReservedCommandWord_throwsCommandException() {
+    public void run_aliasNameIsReservedCommandWord_throwsCommandException() {
         AliasCommand command = new AliasCommand(AliasTestUtil.ALIAS_NAME_ADD);
-        assertThrows(CommandException.class, () -> command.execute(model));
+        assertThrows(CommandException.class, () -> command.run(model));
     }
 
     @Test
-    public void execute_aliasCommandWordIsAlias_throwsCommandException() {
+    public void run_aliasCommandWordIsAlias_throwsCommandException() {
         AliasCommand command = new AliasCommand(AliasTestUtil.ALIAS_TO_ALIAS);
-        assertThrows(CommandException.class, () -> command.execute(model));
+        assertThrows(CommandException.class, () -> command.run(model));
     }
 
     @Test
-    public void execute_aliasCommandIsValid_success() {
+    public void run_aliasCommandIsValid_success() {
         expectedModel.addUserAlias(ALIAS_A_TO_B);
         assertCommandSuccess(
                 new AliasCommand(ALIAS_A_TO_B), model,

--- a/src/test/java/seedu/address/logic/commands/ClearCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/ClearCommandTest.java
@@ -13,7 +13,7 @@ import seedu.address.model.UserPrefs;
 public class ClearCommandTest {
 
     @Test
-    public void execute_emptyAddressBook_success() {
+    public void run_emptyAddressBook_success() {
         Model model = new ModelManager();
         Model expectedModel = new ModelManager();
 
@@ -21,7 +21,7 @@ public class ClearCommandTest {
     }
 
     @Test
-    public void execute_nonEmptyAddressBook_success() {
+    public void run_nonEmptyAddressBook_success() {
         Model model = new ModelManager(getTypicalAddressBook(), new UserPrefs());
         Model expectedModel = new ModelManager(getTypicalAddressBook(), new UserPrefs());
         expectedModel.setAddressBook(new AddressBook());

--- a/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
+++ b/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
@@ -69,7 +69,7 @@ public class CommandTestUtil {
     public static void assertCommandSuccess(Command command, Model actualModel, CommandResult expectedCommandResult,
             Model expectedModel) {
         try {
-            CommandResult result = command.execute(actualModel);
+            CommandResult result = command.run(actualModel);
             assertEquals(expectedCommandResult, result);
             assertEquals(expectedModel, actualModel);
         } catch (CommandException ce) {
@@ -99,7 +99,7 @@ public class CommandTestUtil {
         AddressBook expectedAddressBook = new AddressBook(actualModel.getAddressBook());
         List<Expense> expectedFilteredList = new ArrayList<>(actualModel.getFilteredExpenseList());
 
-        assertThrows(CommandException.class, expectedMessage, () -> command.execute(actualModel));
+        assertThrows(CommandException.class, expectedMessage, () -> command.run(actualModel));
         assertEquals(expectedAddressBook, actualModel.getAddressBook());
         assertEquals(expectedFilteredList, actualModel.getFilteredExpenseList());
     }

--- a/src/test/java/seedu/address/logic/commands/DeleteCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/DeleteCommandTest.java
@@ -27,7 +27,7 @@ public class DeleteCommandTest {
     private Model model = new ModelManager(getTypicalAddressBook(), new UserPrefs());
 
     @Test
-    public void execute_validIndexUnfilteredList_success() {
+    public void run_validIndexUnfilteredList_success() {
         Expense expenseToDelete = model.getFilteredExpenseList().get(INDEX_FIRST_EXPENSE.getZeroBased());
         DeleteCommand deleteCommand = new DeleteCommand(INDEX_FIRST_EXPENSE);
 
@@ -40,7 +40,7 @@ public class DeleteCommandTest {
     }
 
     @Test
-    public void execute_invalidIndexUnfilteredList_throwsCommandException() {
+    public void run_invalidIndexUnfilteredList_throwsCommandException() {
         Index outOfBoundIndex = Index.fromOneBased(model.getFilteredExpenseList().size() + 1);
         DeleteCommand deleteCommand = new DeleteCommand(outOfBoundIndex);
 
@@ -48,7 +48,7 @@ public class DeleteCommandTest {
     }
 
     @Test
-    public void execute_validIndexFilteredList_success() {
+    public void run_validIndexFilteredList_success() {
         showExpenseAtIndex(model, INDEX_FIRST_EXPENSE);
 
         Expense expenseToDelete = model.getFilteredExpenseList().get(INDEX_FIRST_EXPENSE.getZeroBased());
@@ -64,7 +64,7 @@ public class DeleteCommandTest {
     }
 
     @Test
-    public void execute_invalidIndexFilteredList_throwsCommandException() {
+    public void run_invalidIndexFilteredList_throwsCommandException() {
         showExpenseAtIndex(model, INDEX_FIRST_EXPENSE);
 
         Index outOfBoundIndex = INDEX_SECOND_EXPENSE;

--- a/src/test/java/seedu/address/logic/commands/EditCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/EditCommandTest.java
@@ -35,7 +35,7 @@ public class EditCommandTest {
     private Model model = new ModelManager(getTypicalAddressBook(), new UserPrefs());
 
     @Test
-    public void execute_allFieldsSpecifiedUnfilteredList_success() {
+    public void run_allFieldsSpecifiedUnfilteredList_success() {
         Expense editedExpense = new ExpenseBuilder().build();
         EditExpenseDescriptor descriptor = new EditExpenseDescriptorBuilder(editedExpense).build();
         EditCommand editCommand = new EditCommand(INDEX_FIRST_EXPENSE, descriptor);
@@ -49,7 +49,7 @@ public class EditCommandTest {
     }
 
     @Test
-    public void execute_someFieldsSpecifiedUnfilteredList_success() {
+    public void run_someFieldsSpecifiedUnfilteredList_success() {
         Index indexLastExpense = Index.fromOneBased(model.getFilteredExpenseList().size());
         Expense lastExpense = model.getFilteredExpenseList().get(indexLastExpense.getZeroBased());
 
@@ -74,7 +74,7 @@ public class EditCommandTest {
     }
 
     @Test
-    public void execute_noFieldSpecifiedUnfilteredList_success() {
+    public void run_noFieldSpecifiedUnfilteredList_success() {
         EditCommand editCommand = new EditCommand(INDEX_FIRST_EXPENSE, new EditExpenseDescriptor());
         Expense editedExpense = model.getFilteredExpenseList().get(INDEX_FIRST_EXPENSE.getZeroBased());
 
@@ -86,7 +86,7 @@ public class EditCommandTest {
     }
 
     @Test
-    public void execute_filteredList_success() {
+    public void run_filteredList_success() {
         showExpenseAtIndex(model, INDEX_FIRST_EXPENSE);
 
         Expense expenseInFilteredList = model
@@ -109,7 +109,7 @@ public class EditCommandTest {
     // Editing an expense to have the same details as another should not result in failure
 
     @Test
-    public void execute_invalidExpenseIndexUnfilteredList_failure() {
+    public void run_invalidExpenseIndexUnfilteredList_failure() {
         Index outOfBoundIndex = Index.fromOneBased(model.getFilteredExpenseList().size() + 1);
         EditExpenseDescriptor descriptor = new EditExpenseDescriptorBuilder()
                 .withDescription(VALID_DESCRIPTION_TRANSPORT).build();
@@ -123,7 +123,7 @@ public class EditCommandTest {
      * but smaller than size of address book
      */
     @Test
-    public void execute_invalidExpenseIndexFilteredList_failure() {
+    public void run_invalidExpenseIndexFilteredList_failure() {
         showExpenseAtIndex(model, INDEX_FIRST_EXPENSE);
         Index outOfBoundIndex = INDEX_SECOND_EXPENSE;
         // ensures that outOfBoundIndex is still in bounds of address book list

--- a/src/test/java/seedu/address/logic/commands/ExitCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/ExitCommandTest.java
@@ -13,7 +13,7 @@ public class ExitCommandTest {
     private Model expectedModel = new ModelManager();
 
     @Test
-    public void execute_exit_success() {
+    public void run_exit_success() {
         CommandResult expectedCommandResult = new CommandResult(MESSAGE_EXIT_ACKNOWLEDGEMENT, false, true);
         assertCommandSuccess(new ExitCommand(), model, expectedCommandResult, expectedModel);
     }

--- a/src/test/java/seedu/address/logic/commands/FindCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/FindCommandTest.java
@@ -55,7 +55,7 @@ public class FindCommandTest {
     }
 
     @Test
-    public void execute_zeroKeywords_noExpenseFound() {
+    public void run_zeroKeywords_noExpenseFound() {
         String expectedMessage = String.format(MESSAGE_EXPENSES_LISTED_OVERVIEW, 0);
         DescriptionContainsKeywordsPredicate predicate = preparePredicate(" ");
         FindCommand command = new FindCommand(predicate);
@@ -65,7 +65,7 @@ public class FindCommandTest {
     }
 
     @Test
-    public void execute_multipleKeywords_multipleExpensesFound() {
+    public void run_multipleKeywords_multipleExpensesFound() {
         String expectedMessage = String.format(MESSAGE_EXPENSES_LISTED_OVERVIEW, 3);
         DescriptionContainsKeywordsPredicate predicate = preparePredicate("the Chicken Movie");
         FindCommand command = new FindCommand(predicate);

--- a/src/test/java/seedu/address/logic/commands/HelpCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/HelpCommandTest.java
@@ -13,7 +13,7 @@ public class HelpCommandTest {
     private Model expectedModel = new ModelManager();
 
     @Test
-    public void execute_help_success() {
+    public void run_help_success() {
         CommandResult expectedCommandResult = new CommandResult(SHOWING_HELP_MESSAGE, true, false);
         assertCommandSuccess(new HelpCommand(), model, expectedCommandResult, expectedModel);
     }

--- a/src/test/java/seedu/address/logic/commands/ListCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/ListCommandTest.java
@@ -27,12 +27,12 @@ public class ListCommandTest {
     }
 
     @Test
-    public void execute_listIsNotFiltered_showsSameList() {
+    public void run_listIsNotFiltered_showsSameList() {
         assertCommandSuccess(new ListCommand(), model, ListCommand.MESSAGE_SUCCESS, expectedModel);
     }
 
     @Test
-    public void execute_listIsFiltered_showsEverything() {
+    public void run_listIsFiltered_showsEverything() {
         showExpenseAtIndex(model, INDEX_FIRST_EXPENSE);
         assertCommandSuccess(new ListCommand(), model, ListCommand.MESSAGE_SUCCESS, expectedModel);
     }


### PR DESCRIPTION
Summary:
- The `Command` class now has two abstract methods, `validate` and `execute`, and one concrete method, `run`.
- `run` executes the command with validation (just like the previous execute) and `execute` is the same but with NO validation.
- `validate` and `execute` are supposed to be internal methods, while `run` is exposed for public use (e.g. `LogicManager`, tests, etc).

Reason for separation:
- Separates validation from business logic
- Helps with undo/redo functionality in #74 , so I can override `run` to store the model's state after validation but before execution.

I have already modified test names and utilities to adhere to this naming. All tests have passed.

Implications for future developments:
- All commands have to implement `validate` even when it does not need validation (look at what I did for `exit`, etc).
- You still develop new commands the same way as usual, with `execute`.