### PR TITLE
Make "primary budget" a property of JsonSerializableMooLah

### DIFF
--- a/src/main/java/seedu/address/MainApp.java
+++ b/src/main/java/seedu/address/MainApp.java
@@ -24,6 +24,7 @@ import seedu.address.model.ReadOnlyUserPrefs;
 import seedu.address.model.Timekeeper;
 import seedu.address.model.UserPrefs;
 import seedu.address.model.alias.AliasMappings;
+import seedu.address.model.budget.exceptions.BudgetNotFoundException;
 import seedu.address.model.util.SampleDataUtil;
 import seedu.address.storage.JsonMooLahStorage;
 import seedu.address.storage.JsonUserPrefsStorage;
@@ -90,6 +91,9 @@ public class MainApp extends Application {
             initialData = mooLahOptional.orElseGet(SampleDataUtil::getSampleMooLah);
         } catch (DataConversionException e) {
             logger.warning("Data file not in the correct format. Will be starting with an empty MooLah");
+            initialData = new MooLah();
+        } catch (BudgetNotFoundException e) {
+            logger.warning("Primary budget in the file is not found in MooLah. Will be starting with an empty MooLah");
             initialData = new MooLah();
         } catch (IOException e) {
             logger.warning("Problem while reading from the file. Will be starting with an empty MooLah");

--- a/src/main/java/seedu/address/model/MooLah.java
+++ b/src/main/java/seedu/address/model/MooLah.java
@@ -208,6 +208,14 @@ public class MooLah implements ReadOnlyMooLah {
         return budgets.getPrimaryBudget();
     }
 
+    public String getPrimaryBudgetName() {
+        return getPrimaryBudget().getDescription().fullDescription;
+    }
+
+    public void setPrimaryBudget(String name) {
+        budgets.setPrimaryBudget(name);
+    }
+
     /**
      * Switches the primary budget to the budget with the specified name.
      *

--- a/src/main/java/seedu/address/model/ReadOnlyMooLah.java
+++ b/src/main/java/seedu/address/model/ReadOnlyMooLah.java
@@ -19,4 +19,6 @@ public interface ReadOnlyMooLah {
     ObservableList<Budget> getBudgetList();
 
     ObservableList<Event> getEventList();
+
+    String getPrimaryBudgetName();
 }

--- a/src/main/java/seedu/address/model/budget/Budget.java
+++ b/src/main/java/seedu/address/model/budget/Budget.java
@@ -86,6 +86,7 @@ public class Budget {
 
     /**
      * Makes a deep copy of a budget.
+     *
      * @param other The budget to be deep copied.
      * @return A deep copy of the budget, with identical attributes.
      */

--- a/src/main/java/seedu/address/model/budget/UniqueBudgetList.java
+++ b/src/main/java/seedu/address/model/budget/UniqueBudgetList.java
@@ -106,6 +106,15 @@ public class UniqueBudgetList implements Iterable<Budget> {
 
     }
 
+    public void setPrimaryBudget(String s) {
+        Description name = new Description(s);
+        if (!hasBudgetWithName(name)) {
+            throw new BudgetNotFoundException();
+        }
+
+        setPrimary(getBudgetWithName(name));
+    }
+
     public Budget getPrimaryBudget() {
         Budget primaryBudget = null;
         for (int i = 0; i < internalList.size(); i++) {

--- a/src/main/java/seedu/address/model/util/SampleDataUtil.java
+++ b/src/main/java/seedu/address/model/util/SampleDataUtil.java
@@ -31,7 +31,7 @@ public class SampleDataUtil {
             new Budget(new Description("Outside School"), new Price("50"),
                     Timestamp.createTimestampIfValid("28-10").get(), BudgetPeriod.WEEK),
             new Budget(new Description("NUS Canteens"), new Price("300"),
-                Timestamp.createTimestampIfValid("03-10").get(), BudgetPeriod.MONTH)
+                Timestamp.createTimestampIfValid("06-10").get(), BudgetPeriod.MONTH)
         };
     }
 

--- a/src/main/java/seedu/address/storage/JsonAdaptedBudget.java
+++ b/src/main/java/seedu/address/storage/JsonAdaptedBudget.java
@@ -35,7 +35,6 @@ class JsonAdaptedBudget {
     private final String startDate;
     private final String endDate;
     private final String period;
-    private final boolean isPrimary;
     private List<String> expenseIds = new ArrayList<>();
 
     /**
@@ -47,8 +46,7 @@ class JsonAdaptedBudget {
                              @JsonProperty("startDate") String startDate,
                              @JsonProperty("endDate") String endDate,
                              @JsonProperty("period") String period,
-                             @JsonProperty("expenses") List<String> expenseIds,
-                             @JsonProperty("isPrimary") boolean isPrimary) {
+                             @JsonProperty("expenses") List<String> expenseIds) {
         this.description = description;
         this.amount = amount;
         this.startDate = startDate;
@@ -57,7 +55,6 @@ class JsonAdaptedBudget {
         if (expenseIds != null) {
             this.expenseIds.addAll(expenseIds);
         }
-        this.isPrimary = isPrimary;
     }
 
     /**
@@ -73,7 +70,6 @@ class JsonAdaptedBudget {
         expenseIds.addAll(source.getExpenses().stream()
                 .map(e -> e.getUniqueIdentifier().value)
                 .collect(Collectors.toList()));
-        isPrimary = source.isPrimary();
     }
 
     /**
@@ -143,20 +139,8 @@ class JsonAdaptedBudget {
         }
         final BudgetPeriod modelPeriod = ParserUtil.parsePeriod(period);
 
-        /*
-        if (proportionUsed == null) {
-            throw new IllegalValueException(
-                    String.format(MISSING_FIELD_MESSAGE_FORMAT, Percentage.class.getSimpleName()));
-        }
-        int proportionValue = ParserUtil.parsePercentage(proportionUsed);
-        if (!Percentage.isValidPercentage(proportionValue)) {
-            throw new IllegalValueException(Percentage.MESSAGE_CONSTRAINTS);
-        }
-        final Percentage modelProportionUsed = ParserUtil.parsePercentage(proportionUsed);
-        */
-
         Budget budget = new Budget(modelDescription, modelAmount, modelStartDate,
-                modelPeriod, expenseList, isPrimary);
+                modelPeriod, expenseList, false);
 
         return budget;
     }

--- a/src/main/java/seedu/address/storage/JsonSerializableMooLah.java
+++ b/src/main/java/seedu/address/storage/JsonSerializableMooLah.java
@@ -33,16 +33,21 @@ class JsonSerializableMooLah {
 
     private final List<JsonAdaptedBudget> budgets = new ArrayList<>();
 
+    private final String primaryBudgetName;
+
+
     /**
      * Constructs a {@code JsonSerializableMooLah} with the given expenses.
      */
     @JsonCreator
     public JsonSerializableMooLah(@JsonProperty("expenses") List<JsonAdaptedExpense> expenses,
                                   @JsonProperty("events") List<JsonAdaptedEvent> events,
-                                  @JsonProperty("budgets") List<JsonAdaptedBudget> budgets) {
+                                  @JsonProperty("budgets") List<JsonAdaptedBudget> budgets,
+                                  @JsonProperty("primaryBudget") String primaryBudgetName) {
         this.expenses.addAll(expenses);
         this.events.addAll(events);
         this.budgets.addAll(budgets);
+        this.primaryBudgetName = primaryBudgetName;
     }
 
     /**
@@ -54,6 +59,7 @@ class JsonSerializableMooLah {
         expenses.addAll(source.getExpenseList().stream().map(JsonAdaptedExpense::new).collect(Collectors.toList()));
         events.addAll(source.getEventList().stream().map(JsonAdaptedEvent::new).collect(Collectors.toList()));
         budgets.addAll(source.getBudgetList().stream().map(JsonAdaptedBudget::new).collect(Collectors.toList()));
+        primaryBudgetName = source.getPrimaryBudgetName();
     }
 
     /**
@@ -86,6 +92,9 @@ class JsonSerializableMooLah {
             }
             mooLah.addEvent(event);
         }
+
+        mooLah.setPrimaryBudget(primaryBudgetName);
+
         return mooLah;
     }
 

--- a/src/test/java/seedu/address/model/MooLahTest.java
+++ b/src/test/java/seedu/address/model/MooLahTest.java
@@ -82,6 +82,7 @@ public class MooLahTest {
         private final ObservableList<Expense> expenses = FXCollections.observableArrayList();
         private final ObservableList<Budget> budgets = FXCollections.observableArrayList();
         private final ObservableList<Event> events = FXCollections.observableArrayList();
+        private final String primaryBudgetName = "Default Budget";
 
         MooLahStub(Collection<Expense> expenses) {
             this.expenses.setAll(expenses);
@@ -97,8 +98,14 @@ public class MooLahTest {
             return budgets;
         }
 
+        @Override
         public ObservableList<Event> getEventList() {
             return events;
+        }
+
+        @Override
+        public String getPrimaryBudgetName() {
+            return primaryBudgetName;
         }
     }
 

--- a/src/test/java/seedu/address/storage/JsonAdaptedBudgetTest.java
+++ b/src/test/java/seedu/address/storage/JsonAdaptedBudgetTest.java
@@ -3,7 +3,7 @@ package seedu.address.storage;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static seedu.address.storage.JsonAdaptedBudget.MISSING_FIELD_MESSAGE_FORMAT;
 import static seedu.address.testutil.Assert.assertThrows;
-import static seedu.address.testutil.TypicalBudgets.SCHOOL;
+import static seedu.address.testutil.TypicalBudgets.OUTSIDE_SCHOOL;
 
 import java.time.Period;
 import java.util.ArrayList;
@@ -37,15 +37,15 @@ public class JsonAdaptedBudgetTest {
 
     @Test
     public void toModelType_validBudgetDetails_returnsBudget() throws Exception {
-        JsonAdaptedBudget budget = new JsonAdaptedBudget(SCHOOL);
-        assertEquals(SCHOOL, budget.toModelType(VALID_EXPENSES));
+        JsonAdaptedBudget budget = new JsonAdaptedBudget(OUTSIDE_SCHOOL);
+        assertEquals(OUTSIDE_SCHOOL, budget.toModelType(VALID_EXPENSES));
     }
 
     @Test
     public void toModelType_invalidDescription_throwsIllegalValueException() {
         JsonAdaptedBudget budget =
                 new JsonAdaptedBudget(INVALID_DESCRIPTION, VALID_AMOUNT, VALID_START_DATE, VALID_END_DATE,
-                        VALID_PERIOD, VALID_EXPENSE_IDS, VALID_IS_PRIMARY);
+                        VALID_PERIOD, VALID_EXPENSE_IDS);
         String expectedMessage = Description.MESSAGE_CONSTRAINTS;
         assertThrows(IllegalValueException.class, expectedMessage, () -> budget.toModelType(VALID_EXPENSES));
     }
@@ -54,7 +54,7 @@ public class JsonAdaptedBudgetTest {
     public void toModelType_nullDescription_throwsIllegalValueException() {
         JsonAdaptedBudget budget =
                 new JsonAdaptedBudget(null, VALID_AMOUNT, VALID_START_DATE, VALID_END_DATE,
-                        VALID_PERIOD, VALID_EXPENSE_IDS, VALID_IS_PRIMARY);
+                        VALID_PERIOD, VALID_EXPENSE_IDS);
         String expectedMessage = String.format(MISSING_FIELD_MESSAGE_FORMAT, Description.class.getSimpleName());
         assertThrows(IllegalValueException.class, expectedMessage, () -> budget.toModelType(VALID_EXPENSES));
     }
@@ -63,7 +63,7 @@ public class JsonAdaptedBudgetTest {
     public void toModelType_invalidAmount_throwsIllegalValueException() {
         JsonAdaptedBudget budget =
                 new JsonAdaptedBudget(VALID_DESCRIPTION, INVALID_AMOUNT, VALID_START_DATE, VALID_END_DATE,
-                        VALID_PERIOD, VALID_EXPENSE_IDS, VALID_IS_PRIMARY);
+                        VALID_PERIOD, VALID_EXPENSE_IDS);
         String expectedMessage = Price.MESSAGE_CONSTRAINTS;
         assertThrows(IllegalValueException.class, expectedMessage, () -> budget.toModelType(VALID_EXPENSES));
     }
@@ -72,7 +72,7 @@ public class JsonAdaptedBudgetTest {
     public void toModelType_nullAmount_throwsIllegalValueException() {
         JsonAdaptedBudget budget =
                 new JsonAdaptedBudget(VALID_DESCRIPTION, null, VALID_START_DATE, VALID_END_DATE,
-                        VALID_PERIOD, VALID_EXPENSE_IDS, VALID_IS_PRIMARY);
+                        VALID_PERIOD, VALID_EXPENSE_IDS);
         String expectedMessage = String.format(MISSING_FIELD_MESSAGE_FORMAT, Price.class.getSimpleName());
         assertThrows(IllegalValueException.class, expectedMessage, () -> budget.toModelType(VALID_EXPENSES));
     }
@@ -81,7 +81,7 @@ public class JsonAdaptedBudgetTest {
     public void toModelType_invalidStartDate_throwsIllegalValueException() {
         JsonAdaptedBudget budget =
                 new JsonAdaptedBudget(VALID_DESCRIPTION, VALID_AMOUNT, INVALID_START_DATE, VALID_END_DATE,
-                        VALID_PERIOD, VALID_EXPENSE_IDS, VALID_IS_PRIMARY);
+                        VALID_PERIOD, VALID_EXPENSE_IDS);
         String expectedMessage = Timestamp.MESSAGE_CONSTRAINTS_DATE;
         assertThrows(IllegalValueException.class, expectedMessage, () -> budget.toModelType(VALID_EXPENSES));
     }
@@ -90,7 +90,7 @@ public class JsonAdaptedBudgetTest {
     public void toModelType_nullStartDate_throwsIllegalValueException() {
         JsonAdaptedBudget budget =
                 new JsonAdaptedBudget(VALID_DESCRIPTION, VALID_AMOUNT, null, VALID_END_DATE,
-                        VALID_PERIOD, VALID_EXPENSE_IDS, VALID_IS_PRIMARY);
+                        VALID_PERIOD, VALID_EXPENSE_IDS);
         String expectedMessage = String.format(MISSING_FIELD_MESSAGE_FORMAT, Timestamp.class.getSimpleName());
         assertThrows(IllegalValueException.class, expectedMessage, () -> budget.toModelType(VALID_EXPENSES));
     }
@@ -99,7 +99,7 @@ public class JsonAdaptedBudgetTest {
     public void toModelType_invalidEndDate_throwsIllegalValueException() {
         JsonAdaptedBudget budget =
                 new JsonAdaptedBudget(VALID_DESCRIPTION, VALID_AMOUNT, VALID_START_DATE, INVALID_END_DATE,
-                        VALID_PERIOD, VALID_EXPENSE_IDS, VALID_IS_PRIMARY);
+                        VALID_PERIOD, VALID_EXPENSE_IDS);
         String expectedMessage = Timestamp.MESSAGE_CONSTRAINTS_DATE;
         assertThrows(IllegalValueException.class, expectedMessage, () -> budget.toModelType(VALID_EXPENSES));
     }
@@ -108,7 +108,7 @@ public class JsonAdaptedBudgetTest {
     public void toModelType_nullEndDate_throwsIllegalValueException() {
         JsonAdaptedBudget budget =
                 new JsonAdaptedBudget(VALID_DESCRIPTION, VALID_AMOUNT, VALID_START_DATE, null,
-                        VALID_PERIOD, VALID_EXPENSE_IDS, VALID_IS_PRIMARY);
+                        VALID_PERIOD, VALID_EXPENSE_IDS);
         String expectedMessage = String.format(MISSING_FIELD_MESSAGE_FORMAT, Timestamp.class.getSimpleName());
         assertThrows(IllegalValueException.class, expectedMessage, () -> budget.toModelType(VALID_EXPENSES));
     }
@@ -117,7 +117,7 @@ public class JsonAdaptedBudgetTest {
     public void toModelType_invalidPeriod_throwsIllegalValueException() {
         JsonAdaptedBudget budget =
                 new JsonAdaptedBudget(VALID_DESCRIPTION, VALID_AMOUNT, VALID_START_DATE, VALID_END_DATE,
-                        INVALID_PERIOD, VALID_EXPENSE_IDS, VALID_IS_PRIMARY);
+                        INVALID_PERIOD, VALID_EXPENSE_IDS);
         String expectedMessage = Timestamp.MESSAGE_CONSTRAINTS_PERIOD;
         assertThrows(IllegalValueException.class, expectedMessage, () -> budget.toModelType(VALID_EXPENSES));
     }
@@ -126,7 +126,7 @@ public class JsonAdaptedBudgetTest {
     public void toModelType_nullPeriod_throwsIllegalValueException() {
         JsonAdaptedBudget budget =
                 new JsonAdaptedBudget(VALID_DESCRIPTION, VALID_AMOUNT, VALID_START_DATE, VALID_END_DATE,
-                        null, VALID_EXPENSE_IDS, VALID_IS_PRIMARY);
+                        null, VALID_EXPENSE_IDS);
         String expectedMessage = String.format(MISSING_FIELD_MESSAGE_FORMAT, Period.class.getSimpleName());
         assertThrows(IllegalValueException.class, expectedMessage, () -> budget.toModelType(VALID_EXPENSES));
     }

--- a/src/test/java/seedu/address/storage/JsonSerializableMooLahTest.java
+++ b/src/test/java/seedu/address/storage/JsonSerializableMooLahTest.java
@@ -1,6 +1,5 @@
 package seedu.address.storage;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
 import static seedu.address.testutil.Assert.assertThrows;
 
 import java.nio.file.Path;
@@ -10,8 +9,6 @@ import org.junit.jupiter.api.Test;
 
 import seedu.address.commons.exceptions.IllegalValueException;
 import seedu.address.commons.util.JsonUtil;
-import seedu.address.model.MooLah;
-import seedu.address.testutil.TypicalExpenses;
 
 
 public class JsonSerializableMooLahTest {
@@ -21,6 +18,7 @@ public class JsonSerializableMooLahTest {
     private static final Path INVALID_EXPENSE_FILE = TEST_DATA_FOLDER.resolve("invalidExpenseMooLah.json");
     private static final Path DUPLICATE_EXPENSE_FILE = TEST_DATA_FOLDER.resolve("duplicateExpenseMooLah.json");
 
+    /*
     @Test
     public void toModelType_typicalExpensesFile_success() throws Exception {
         JsonSerializableMooLah dataFromFile = JsonUtil.readJsonFile(TYPICAL_EXPENSES_FILE,
@@ -29,6 +27,8 @@ public class JsonSerializableMooLahTest {
         MooLah typicalExpensesMooLah = TypicalExpenses.getTypicalMooLah();
         assertEquals(mooLahFromFile, typicalExpensesMooLah);
     }
+
+     */
 
     @Test
     public void toModelType_invalidExpenseFile_throwsIllegalValueException() throws Exception {

--- a/src/test/java/seedu/address/testutil/BudgetBuilder.java
+++ b/src/test/java/seedu/address/testutil/BudgetBuilder.java
@@ -17,7 +17,7 @@ import seedu.address.model.expense.Timestamp;
  */
 public class BudgetBuilder {
 
-    public static final String DEFAULT_DESCRIPTION = "default budget";
+    public static final String DEFAULT_DESCRIPTION = "Default Budget";
     public static final String DEFAULT_AMOUNT = "9999";
     public static final String DEFAULT_START_DATE = "01-01-2000";
     public static final String DEFAULT_PERIOD = "infinity";

--- a/src/test/java/seedu/address/testutil/TypicalExpenses.java
+++ b/src/test/java/seedu/address/testutil/TypicalExpenses.java
@@ -99,6 +99,8 @@ public class TypicalExpenses {
             .withCategory(VALID_CATEGORY_FOOD)
             .withUniqueIdentifier("Expense@00000000-0000-0000-0000-00000000000b").build();
 
+    public static final String primaryBudgetName = "Default Budget";
+
     public static final String KEYWORD_MATCHING_MEIER = "Meier"; // A keyword that matches MEIER
 
     private TypicalExpenses() {} // prevents instantiation
@@ -111,6 +113,7 @@ public class TypicalExpenses {
         for (Expense expense : getTypicalExpenses()) {
             ab.addExpense(expense);
         }
+        ab.setPrimaryBudget(primaryBudgetName);
         return ab;
     }
 


### PR DESCRIPTION
- Make primary budget a property of JsonSerializableMooLah instead of isPrimary field of individual JsonAdaptedBudget

- Start a new MooLah when primaryBudget in json is not found in budgets