### PR TITLE
Bug fixes & code quality improvements

### DIFF
--- a/src/main/java/seedu/address/logic/commands/alias/AddAliasCommand.java
+++ b/src/main/java/seedu/address/logic/commands/alias/AddAliasCommand.java
@@ -27,7 +27,7 @@ public class AddAliasCommand extends UndoableCommand {
             + " findAnimal " + PREFIX_ALIAS_ALIAS_INPUT
             + " find rat rats mouse mice cow cows ox oxen tiger tigers";
 
-    public static final String MESSAGE_SUCCESS = "Alias created: %1$s";
+    public static final String MESSAGE_SUCCESS = "Alias created:\n %1$s";
 
     public static final String MESSAGE_RESERVED_NAME =
             "%1$s is a reserved command name and cannot be used for an alias name";

--- a/src/main/java/seedu/address/logic/commands/alias/DeleteAliasCommand.java
+++ b/src/main/java/seedu/address/logic/commands/alias/DeleteAliasCommand.java
@@ -21,7 +21,7 @@ public class DeleteAliasCommand extends UndoableCommand {
             + "Parameters: <alias name>\n"
             + "Example: deletealias findCat";
 
-    public static final String MESSAGE_SUCCESS = "Alias deleted: %1$s";
+    public static final String MESSAGE_SUCCESS = "Alias deleted:\n %1$s";
 
     public static final String MESSAGE_FAILURE = "There is no Alias with the following name: \"%s\"";
 

--- a/src/main/java/seedu/address/logic/commands/budget/DeleteBudgetByIndexCommand.java
+++ b/src/main/java/seedu/address/logic/commands/budget/DeleteBudgetByIndexCommand.java
@@ -26,7 +26,7 @@ public class DeleteBudgetByIndexCommand extends UndoableCommand {
             + "Parameters: INDEX (must be a positive integer)\n"
             + "Example: " + COMMAND_WORD + " 1";
 
-    public static final String MESSAGE_DELETE_BUDGET_SUCCESS = "Deleted Budget: %1$s";
+    public static final String MESSAGE_DELETE_BUDGET_SUCCESS = "Deleted Budget:\n %1$s";
 
     private final Index targetIndex;
 
@@ -49,6 +49,11 @@ public class DeleteBudgetByIndexCommand extends UndoableCommand {
         }
 
         if (lastShownList.size() == 1) {
+            throw new CommandException(Messages.MESSAGE_CANNOT_DELETE_DEFAULT_BUDGET);
+        }
+
+        Budget budgetToDelete = lastShownList.get(targetIndex.getZeroBased());
+        if (budgetToDelete.isDefaultBudget()) {
             throw new CommandException(Messages.MESSAGE_CANNOT_DELETE_DEFAULT_BUDGET);
         }
     }

--- a/src/main/java/seedu/address/logic/commands/budget/DeleteBudgetByNameCommand.java
+++ b/src/main/java/seedu/address/logic/commands/budget/DeleteBudgetByNameCommand.java
@@ -7,6 +7,7 @@ import static seedu.address.model.budget.Budget.DEFAULT_BUDGET_DESCRIPTION;
 import seedu.address.commons.core.Messages;
 import seedu.address.logic.commands.CommandGroup;
 import seedu.address.logic.commands.CommandResult;
+import seedu.address.logic.commands.GenericCommandWord;
 import seedu.address.logic.commands.UndoableCommand;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.Model;
@@ -18,7 +19,7 @@ import seedu.address.ui.budget.BudgetListPanel;
  */
 public class DeleteBudgetByNameCommand extends UndoableCommand {
 
-    public static final String COMMAND_WORD = "delete" + CommandGroup.BUDGET;
+    public static final String COMMAND_WORD = GenericCommandWord.DELETE + CommandGroup.BUDGET;
     public static final String COMMAND_DESCRIPTION = "Delete budget with name %1$s";
     public static final String MESSAGE_USAGE = COMMAND_WORD
             + ": Deletes the budget identified by the name.\n"

--- a/src/main/java/seedu/address/logic/commands/budget/DeleteBudgetByNameCommand.java
+++ b/src/main/java/seedu/address/logic/commands/budget/DeleteBudgetByNameCommand.java
@@ -2,7 +2,9 @@ package seedu.address.logic.commands.budget;
 
 import static java.util.Objects.requireNonNull;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_DESCRIPTION;
+import static seedu.address.model.budget.Budget.DEFAULT_BUDGET_DESCRIPTION;
 
+import seedu.address.commons.core.Messages;
 import seedu.address.logic.commands.CommandGroup;
 import seedu.address.logic.commands.CommandResult;
 import seedu.address.logic.commands.UndoableCommand;
@@ -25,7 +27,7 @@ public class DeleteBudgetByNameCommand extends UndoableCommand {
             + "Example: " + COMMAND_WORD + " "
             + PREFIX_DESCRIPTION + "Holiday";
 
-    public static final String MESSAGE_DELETE_BUDGET_SUCCESS = "Deleted Budget: %1$s";
+    public static final String MESSAGE_DELETE_BUDGET_SUCCESS = "Deleted Budget:\n %1$s";
     public static final String MESSAGE_BUDGET_NOT_FOUND = "This budget does not exist in MooLah";
 
     private final Description description;
@@ -49,6 +51,10 @@ public class DeleteBudgetByNameCommand extends UndoableCommand {
 
         if (!model.hasBudgetWithName(description)) {
             throw new CommandException(MESSAGE_BUDGET_NOT_FOUND);
+        }
+
+        if (description.equals(DEFAULT_BUDGET_DESCRIPTION)) {
+            throw new CommandException(Messages.MESSAGE_CANNOT_DELETE_DEFAULT_BUDGET);
         }
     }
 

--- a/src/main/java/seedu/address/logic/commands/budget/DeleteExpenseFromBudgetCommand.java
+++ b/src/main/java/seedu/address/logic/commands/budget/DeleteExpenseFromBudgetCommand.java
@@ -6,7 +6,9 @@ import java.util.List;
 
 import seedu.address.commons.core.Messages;
 import seedu.address.commons.core.index.Index;
+import seedu.address.logic.commands.CommandGroup;
 import seedu.address.logic.commands.CommandResult;
+import seedu.address.logic.commands.GenericCommandWord;
 import seedu.address.logic.commands.UndoableCommand;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.Model;
@@ -17,7 +19,7 @@ import seedu.address.ui.budget.BudgetPanel;
  * Dummy.
  */
 public class DeleteExpenseFromBudgetCommand extends UndoableCommand {
-    public static final String COMMAND_WORD = "deletefrombudget";
+    public static final String COMMAND_WORD = GenericCommandWord.DELETE + "from" + CommandGroup.BUDGET;
     public static final String COMMAND_DESCRIPTION = "Delete expense with index %1$d from budget";
     public static final String MESSAGE_USAGE = COMMAND_WORD
             + ": Deletes the expense identified by the index number used in the "

--- a/src/main/java/seedu/address/logic/commands/budget/DeleteExpenseFromBudgetCommand.java
+++ b/src/main/java/seedu/address/logic/commands/budget/DeleteExpenseFromBudgetCommand.java
@@ -25,7 +25,7 @@ public class DeleteExpenseFromBudgetCommand extends UndoableCommand {
             + "Parameters: INDEX (must be a positive integer)\n"
             + "Example: " + COMMAND_WORD + " 1";
 
-    public static final String MESSAGE_DELETE_EXPENSE_SUCCESS = "Deleted Expense: %1$s";
+    public static final String MESSAGE_DELETE_EXPENSE_SUCCESS = "Deleted Expense From Budget:\n %1$s";
 
     private final Index targetIndex;
 

--- a/src/main/java/seedu/address/logic/commands/budget/EditBudgetCommand.java
+++ b/src/main/java/seedu/address/logic/commands/budget/EditBudgetCommand.java
@@ -44,7 +44,7 @@ public class EditBudgetCommand extends UndoableCommand {
             + "Example: " + COMMAND_WORD + " 1 "
             + PREFIX_PRICE + "400 ";
 
-    public static final String MESSAGE_EDIT_BUDGET_SUCCESS = "Edited Budget: %1$s";
+    public static final String MESSAGE_EDIT_BUDGET_SUCCESS = "Edited Budget:\n %1$s";
     public static final String MESSAGE_NOT_EDITED = "At least one field to edit must be provided.";
     public static final String MESSAGE_DEFAULT_BUDGET_UNEDITABLE = "The default budget cannot be edited.";
     public static final String MESSAGE_DUPLICATE_BUDGET = "This budget already exists in the MooLah.";

--- a/src/main/java/seedu/address/logic/commands/budget/EditExpenseFromBudgetCommand.java
+++ b/src/main/java/seedu/address/logic/commands/budget/EditExpenseFromBudgetCommand.java
@@ -11,7 +11,9 @@ import java.util.List;
 
 import seedu.address.commons.core.Messages;
 import seedu.address.commons.core.index.Index;
+import seedu.address.logic.commands.CommandGroup;
 import seedu.address.logic.commands.CommandResult;
+import seedu.address.logic.commands.GenericCommandWord;
 import seedu.address.logic.commands.UndoableCommand;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.logic.commands.expense.EditExpenseCommand;
@@ -27,7 +29,7 @@ import seedu.address.ui.budget.BudgetPanel;
  * Dummy.
  */
 public class EditExpenseFromBudgetCommand extends UndoableCommand {
-    public static final String COMMAND_WORD = "editfrombudget";
+    public static final String COMMAND_WORD = GenericCommandWord.EDIT + "from" + CommandGroup.BUDGET;
     public static final String COMMAND_DESCRIPTION = "Edit expense with index %1$d from budget";
     public static final String MESSAGE_USAGE = COMMAND_WORD + ": Edits the details of the expense identified "
             + "by the index number used in the displayed expense list of this budget. "

--- a/src/main/java/seedu/address/logic/commands/budget/EditExpenseFromBudgetCommand.java
+++ b/src/main/java/seedu/address/logic/commands/budget/EditExpenseFromBudgetCommand.java
@@ -40,7 +40,7 @@ public class EditExpenseFromBudgetCommand extends UndoableCommand {
             + "Example: " + COMMAND_WORD + " 1 "
             + PREFIX_PRICE + "3512.123 ";
 
-    public static final String MESSAGE_EDIT_EXPENSE_SUCCESS = "Edited Expense: %1$s";
+    public static final String MESSAGE_EDIT_EXPENSE_SUCCESS = "Edited Expense from Budget:\n %1$s";
     public static final String MESSAGE_NOT_EDITED = "At least one field to edit must be provided.";
     public static final String MESSAGE_DUPLICATE_EXPENSE = "This expense already exists in the MooLah.";
 

--- a/src/main/java/seedu/address/logic/commands/budget/SwitchBudgetCommand.java
+++ b/src/main/java/seedu/address/logic/commands/budget/SwitchBudgetCommand.java
@@ -24,7 +24,7 @@ public class SwitchBudgetCommand extends UndoableCommand {
             + "Example: " + COMMAND_WORD + " "
             + PREFIX_DESCRIPTION + "Outside School";
 
-    public static final String MESSAGE_SUCCESS = "Primary budget switched to: %1$s";
+    public static final String MESSAGE_SUCCESS = "Primary budget switched to:\n %1$s";
     public static final String MESSAGE_BUDGET_NOT_FOUND = "This budget does not exist in MooLah";
     public static final String MESSAGE_BUDGET_ALREADY_PRIMARY = "This budget is already the primary budget";
 

--- a/src/main/java/seedu/address/logic/commands/event/AddEventCommand.java
+++ b/src/main/java/seedu/address/logic/commands/event/AddEventCommand.java
@@ -35,7 +35,7 @@ public class AddEventCommand extends UndoableCommand {
             + PREFIX_CATEGORY + "Food "
             + PREFIX_TIMESTAMP + "25-12";
 
-    public static final String MESSAGE_SUCCESS = "New event added: %1$s";
+    public static final String MESSAGE_SUCCESS = "New event added:\n %1$s";
     public static final String MESSAGE_DUPLICATE_EVENT = "This event already exists in the tracker";
 
     private final Event toAdd;

--- a/src/main/java/seedu/address/logic/commands/event/DeleteEventCommand.java
+++ b/src/main/java/seedu/address/logic/commands/event/DeleteEventCommand.java
@@ -27,7 +27,7 @@ public class DeleteEventCommand extends UndoableCommand {
             + "Parameters: INDEX (must be a positive integer)\n"
             + "Example: " + COMMAND_WORD + " 1";
 
-    public static final String MESSAGE_DELETE_EVENT_SUCCESS = "Deleted Event: %1$s";
+    public static final String MESSAGE_DELETE_EVENT_SUCCESS = "Deleted Event:\n %1$s";
 
     private final Index targetIndex;
 

--- a/src/main/java/seedu/address/logic/commands/event/EditEventCommand.java
+++ b/src/main/java/seedu/address/logic/commands/event/EditEventCommand.java
@@ -44,7 +44,7 @@ public class EditEventCommand extends UndoableCommand {
             + "Example: " + COMMAND_WORD + " 1 "
             + PREFIX_PRICE + "3512.123 ";
 
-    public static final String MESSAGE_EDIT_EVENT_SUCCESS = "Edited Event: %1$s";
+    public static final String MESSAGE_EDIT_EVENT_SUCCESS = "Edited Event:\n %1$s";
     public static final String MESSAGE_NOT_EDITED = "At least one field to edit must be provided.";
     public static final String MESSAGE_DUPLICATE_EVENT = "This event already exists in MooLah.";
 

--- a/src/main/java/seedu/address/logic/commands/expense/AddExpenseCommand.java
+++ b/src/main/java/seedu/address/logic/commands/expense/AddExpenseCommand.java
@@ -36,7 +36,7 @@ public class AddExpenseCommand extends UndoableCommand {
             + PREFIX_CATEGORY + "Food "
             + PREFIX_TIMESTAMP + "10-10";
 
-    public static final String MESSAGE_SUCCESS = "New expense added: %1$s";
+    public static final String MESSAGE_SUCCESS = "New expense added:\n %1$s";
     public static final String MESSAGE_DUPLICATE_EXPENSE = "This expense already exists in the MooLah";
 
     private final Expense toAdd;

--- a/src/main/java/seedu/address/logic/commands/expense/DeleteExpenseCommand.java
+++ b/src/main/java/seedu/address/logic/commands/expense/DeleteExpenseCommand.java
@@ -8,6 +8,7 @@ import seedu.address.commons.core.Messages;
 import seedu.address.commons.core.index.Index;
 import seedu.address.logic.commands.CommandGroup;
 import seedu.address.logic.commands.CommandResult;
+import seedu.address.logic.commands.GenericCommandWord;
 import seedu.address.logic.commands.UndoableCommand;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.Model;
@@ -19,7 +20,7 @@ import seedu.address.ui.expense.ExpenseListPanel;
  */
 public class DeleteExpenseCommand extends UndoableCommand {
 
-    public static final String COMMAND_WORD = "delete" + CommandGroup.EXPENSE;
+    public static final String COMMAND_WORD = GenericCommandWord.DELETE + CommandGroup.EXPENSE;
     public static final String COMMAND_DESCRIPTION = "Delete expense with index %1$d";
     public static final String MESSAGE_USAGE = COMMAND_WORD
             + ": Deletes the expense identified by the index number used in the displayed expense list.\n"

--- a/src/main/java/seedu/address/logic/commands/expense/DeleteExpenseCommand.java
+++ b/src/main/java/seedu/address/logic/commands/expense/DeleteExpenseCommand.java
@@ -26,7 +26,7 @@ public class DeleteExpenseCommand extends UndoableCommand {
             + "Parameters: INDEX (must be a positive integer)\n"
             + "Example: " + COMMAND_WORD + " 1";
 
-    public static final String MESSAGE_DELETE_EXPENSE_SUCCESS = "Deleted Expense: %1$s";
+    public static final String MESSAGE_DELETE_EXPENSE_SUCCESS = "Deleted Expense:\n %1$s";
 
     private final Index targetIndex;
 

--- a/src/main/java/seedu/address/logic/commands/expense/EditExpenseCommand.java
+++ b/src/main/java/seedu/address/logic/commands/expense/EditExpenseCommand.java
@@ -15,6 +15,7 @@ import seedu.address.commons.core.index.Index;
 import seedu.address.commons.util.CollectionUtil;
 import seedu.address.logic.commands.CommandGroup;
 import seedu.address.logic.commands.CommandResult;
+import seedu.address.logic.commands.GenericCommandWord;
 import seedu.address.logic.commands.UndoableCommand;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.Model;
@@ -30,7 +31,7 @@ import seedu.address.ui.expense.ExpenseListPanel;
  */
 public class EditExpenseCommand extends UndoableCommand {
 
-    public static final String COMMAND_WORD = "edit" + CommandGroup.EXPENSE;
+    public static final String COMMAND_WORD = GenericCommandWord.EDIT + CommandGroup.EXPENSE;
     public static final String COMMAND_DESCRIPTION = "Edit expense with index %1$d";
     public static final String MESSAGE_USAGE = COMMAND_WORD + ": Edits the details of the expense identified "
             + "by the index number used in the displayed expense list. "

--- a/src/main/java/seedu/address/logic/commands/expense/EditExpenseCommand.java
+++ b/src/main/java/seedu/address/logic/commands/expense/EditExpenseCommand.java
@@ -43,7 +43,7 @@ public class EditExpenseCommand extends UndoableCommand {
             + "Example: " + COMMAND_WORD + " 1 "
             + PREFIX_PRICE + "3512.123 ";
 
-    public static final String MESSAGE_EDIT_EXPENSE_SUCCESS = "Edited Expense: %1$s";
+    public static final String MESSAGE_EDIT_EXPENSE_SUCCESS = "Edited Expense:\n %1$s";
     public static final String MESSAGE_NOT_EDITED = "At least one field to edit must be provided.";
     public static final String MESSAGE_DUPLICATE_EXPENSE = "This expense already exists in MooLah.";
 

--- a/src/main/java/seedu/address/model/MooLah.java
+++ b/src/main/java/seedu/address/model/MooLah.java
@@ -92,6 +92,7 @@ public class MooLah implements ReadOnlyMooLah {
         setExpenses(newData.getExpenseList());
         setBudgets(newData.getBudgetList());
         setEvents(newData.getEventList());
+        budgets.handleDuplicatePrimaryBudgets();
         //resetBudgetExpenseLists();
     }
 

--- a/src/main/java/seedu/address/model/budget/UniqueBudgetList.java
+++ b/src/main/java/seedu/address/model/budget/UniqueBudgetList.java
@@ -5,6 +5,7 @@ import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
 
 import java.util.Iterator;
 import java.util.List;
+import java.util.stream.Collectors;
 
 import javafx.collections.FXCollections;
 import javafx.collections.ObservableList;
@@ -179,6 +180,16 @@ public class UniqueBudgetList implements Iterable<Budget> {
 
         if (toRemove.isPrimary()) {
             setPrimary(getDefaultBudget());
+        }
+    }
+
+    /**
+     * Handles issue of duplicate primary budgets when undoing "clearbudgets".
+     */
+    public void handleDuplicatePrimaryBudgets() {
+        List<Budget> primaryBudgets = internalList.stream().filter(b -> b.isPrimary()).collect(Collectors.toList());
+        if (primaryBudgets.size() > 1) {
+            getDefaultBudget().setToNotPrimary();
         }
     }
 

--- a/src/main/java/seedu/address/storage/JsonSerializableMooLah.java
+++ b/src/main/java/seedu/address/storage/JsonSerializableMooLah.java
@@ -1,5 +1,7 @@
 package seedu.address.storage;
 
+import static seedu.address.model.budget.Budget.DEFAULT_BUDGET_DESCRIPTION;
+
 import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -93,7 +95,11 @@ class JsonSerializableMooLah {
             mooLah.addEvent(event);
         }
 
-        mooLah.setPrimaryBudget(primaryBudgetName);
+        if (primaryBudgetName != null) {
+            mooLah.setPrimaryBudget(primaryBudgetName);
+        } else {
+            mooLah.setPrimaryBudget(DEFAULT_BUDGET_DESCRIPTION.fullDescription);
+        }
 
         return mooLah;
     }

--- a/src/test/java/seedu/address/logic/parser/AddAliasCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddAliasCommandParserTest.java
@@ -11,7 +11,7 @@ import org.junit.jupiter.api.Test;
 import seedu.address.logic.commands.alias.AddAliasCommand;
 import seedu.address.model.alias.Alias;
 
-public class AddAddAliasCommandParserTest {
+public class AddAliasCommandParserTest {
     private AddAliasCommandParser parser = new AddAliasCommandParser();
 
     @Test


### PR DESCRIPTION
- Fix bug: duplicate primary budgets after undoing "clearbudgets"
- Fix bug: NullPointerException when primaryBudget in json is null (by setting Default Budget to primary)
- Display error message to user in result-display area when trying to delete default budget
- Add line break in command success messages for better result display formatting
- Replace stray strings in COMMAND_WORD with static variables from GenericCommandWord