### PR TITLE
Fix bug: "switchperiod" unable to maintain the status

### DIFF
--- a/src/main/java/seedu/moolah/model/Timekeeper.java
+++ b/src/main/java/seedu/moolah/model/Timekeeper.java
@@ -1,5 +1,6 @@
 package seedu.moolah.model;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.time.temporal.ChronoUnit;
@@ -37,7 +38,15 @@ public class Timekeeper {
      */
     public void updateTime() {
         systemTime = new Timestamp(LocalDateTime.now());
-        refreshBudgets();
+        if (isAtDayBreak(systemTime)) {
+            refreshBudgets();
+        }
+    }
+
+    private boolean isAtDayBreak(Timestamp timeNow) {
+        LocalDate dateNow = timeNow.getDate();
+        LocalDate dateJustNow = timeNow.getDateJustNow();
+        return !dateNow.equals(dateJustNow);
     }
 
     /**

--- a/src/main/java/seedu/moolah/model/expense/Timestamp.java
+++ b/src/main/java/seedu/moolah/model/expense/Timestamp.java
@@ -146,6 +146,10 @@ public class Timestamp implements Comparable<Timestamp> {
         return fullTimestamp.toLocalDate();
     }
 
+    public LocalDate getDateJustNow() {
+        return fullTimestamp.minusSeconds(10).toLocalDate();
+    }
+
     public Timestamp toStartOfDay() {
         return new Timestamp(fullTimestamp.toLocalDate().atStartOfDay());
     }


### PR DESCRIPTION
- It is because budgets refresh every 10 seconds, normalizing back to the current period after a short while
- I've changed the budget refreshing implementation in Timekeeper such that budgets only refresh at day breaks (00:00)